### PR TITLE
django-iconsの導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ TOTAL                              273     15     20      2    94%
 - Top画像 : https://pixabay.com/ja/vectors/%e7%90%86%e5%ae%b9-haircutting-%e9%a0%ad-33118/
 - Docker : https://qiita.com/str416yb/items/7324b99b9f05b9089b80
   - cryptography install : https://cryptography.io/en/latest/installation/#alpine
-- SSL化 : 
-  - https://github.com/SteveLTN/https-portal
+- SSL化 : https://github.com/SteveLTN/https-portal
 - CSS : https://f-tpl.com/tpl_087/
 - 現場で使えるDjangoの教科書シリーズ : https://zenn.dev/akiyoko/articles/6bc03e7f954570

--- a/accounts/templates/account/base.html
+++ b/accounts/templates/account/base.html
@@ -30,11 +30,11 @@
                 <li><a href="{% url 'pointcard' %}">ポイントカード</a></li>
                 <li><a href="{% url 'account_email' %}">メールアドレス登録・変更</a></li>
                 <li><a href="{% url 'account_change_password' %}">パスワード変更</a></li>
-                <li><a href="{% url 'account_reset_password' %}">パスワードをお忘れの方</a></li>
                 <li><a href="{% url 'account_logout' %}">ログアウト</a></li>
                 {% else %}
                 <li><a href="{% url 'account_login' %}">ログイン</a></li>
                 <li><a href="{% url 'account_signup' %}">新規アカウント作成</a></li>
+                <li><a href="{% url 'account_reset_password' %}">パスワードをお忘れの方</a></li>
                 {% endif %}
             </ul>
         </section>

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     'allauth.account',
     'allauth.socialaccount',
     'bootstrap4',
+    'django_icons',
 ]
 
 MIDDLEWARE = [
@@ -116,6 +117,16 @@ AUTH_PASSWORD_VALIDATORS = [
 
 BOOTSTRAP4 = {
     'set_placeholder': False,
+}
+
+###################################################
+# django-icons # bootstrap4はiconをサポートしていない #
+###################################################
+
+DJANGO_ICONS = {
+    "ICONS": {
+        "star": {"name": "fas fa-star fa-5x star-orange"},
+    },
 }
 
 # Internationalization

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -125,7 +125,7 @@ BOOTSTRAP4 = {
 
 DJANGO_ICONS = {
     "ICONS": {
-        "star": {"name": "fas fa-star fa-5x star-orange"},
+        "stamp": {"name": "fas fa-star stamp-color"},
     },
 }
 

--- a/hairsalon/templates/hairsalon/base.html
+++ b/hairsalon/templates/hairsalon/base.html
@@ -8,6 +8,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" type="text/css" media="all" href="{% static 'css/style.css' %}">
+    <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
     <title>{% block page_title %}{% endblock %}</title>
 </head>
 <body>

--- a/pointcard/templates/pointcard/pointcard.html
+++ b/pointcard/templates/pointcard/pointcard.html
@@ -13,8 +13,14 @@
                 {% for h in v %}
                 <td>
                     {% if h %}
-                    {% icon 'star' %}
-                    {{ h.stamped_at|date:"m/d" }}
+                    <span class="fa-stack fa-2x">
+                        <span class="fa-stack-2x">
+                            {% icon 'stamp' %}
+                        </span>
+                        <span class="fa-stack-1x">
+                            {{ h.stamped_at|date:"n/d" }}
+                        </span>
+                    </span>
                     {% endif %}
                 </td>
                 {% endfor %}

--- a/pointcard/templates/pointcard/pointcard.html
+++ b/pointcard/templates/pointcard/pointcard.html
@@ -1,4 +1,5 @@
 {% extends "account/base.html" %}
+{% load icons %}
 {% load static %}
 {% block page_title %}LOGIN PAGE{% endblock %}
 {% block account_content %}
@@ -12,6 +13,7 @@
                 {% for h in v %}
                 <td>
                     {% if h %}
+                    {% icon 'star' %}
                     {{ h.stamped_at|date:"m/d" }}
                     {% endif %}
                 </td>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,7 @@ Django==3.2
 django-allauth==0.44.0
 django-bootstrap4==3.0.1
 django-environ==0.4.5
+django-icons==4.0.0
 django-phonenumber-field==5.2.0
 gunicorn==20.1.0
 idna==2.10

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -286,9 +286,7 @@ ul.footnav li{
 
 
 tr.stamp_frame {
-   line-height: 50px;
-   min-height: 50px;
-   height: 50px;
+   line-height: 70px;
 }
 
 /*************
@@ -301,8 +299,13 @@ tr.stamp_frame {
 }
 
 /*************
-/* iconに使う色
+/* icon
 *************/
-.star-orange {
+
+.stamp-color {
     color: #fecb81;
+}
+
+.fa-stack-1x {
+    font-size: 0.6em;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -299,3 +299,10 @@ tr.stamp_frame {
     display: block;
     float: right;
 }
+
+/*************
+/* iconに使う色
+*************/
+.star-orange {
+    color: #fecb81;
+}


### PR DESCRIPTION
# やったこと
- スタンプにiconを使いたかったが、bootstrap4はiconをサポートしていなかったので、font awesomeを使うことにした。
- django-iconsを導入するほどでもないと思うけど、settingsで使うiconが整理できてよいのではないかと思う。